### PR TITLE
Big set of GWT fixes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=LF

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     api 'com.github.raeleus:stripe:master-SNAPSHOT'
     implementation 'com.github.tommyettinger:jbump:v1.0.0'
     implementation "com.badlogicgames.gdx-video:gdx-video:1.3.2-SNAPSHOT"
-    implementation 'com.github.tommyettinger:gdxWalkable:c8244ed4b0'
+    api 'com.github.tommyettinger:gdxWalkable:33292ee7da'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/html/build.gradle
+++ b/html/build.gradle
@@ -5,8 +5,7 @@ buildscript {
 		maven { url 'https://jitpack.io' }
 	}
 	dependencies {
-	// temporarily uses a JitPack dependency on a working version of Gretty until the next 3.x release
-		classpath "com.github.tommyettinger.gretty:gretty:3.0.4.5"
+		classpath "org.gretty:gretty:3.0.6"
 	}
 }
 apply plugin: "gwt"
@@ -35,9 +34,9 @@ dependencies {
 	implementation "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
     implementation 'com.github.tommyettinger:gdx-backend-gwt:1.100.0'
     implementation 'com.github.tommyettinger:gdx-backend-gwt:1.100.0:sources'
-    api 'com.github.tommyettinger:regexodus:0.1.10:sources'
+    api 'com.github.tommyettinger:regexodus:0.1.12:sources'
     api 'com.rafaskoberg.gdx:typing-label:1.2.0:sources'
-    api 'space.earlygrey:shapedrawer:2.3.0:sources'
+    api 'space.earlygrey:shapedrawer:2.4.0:sources'
     api 'com.github.raeleus.TenPatch:tenpatch:5.2.2:sources'
     api 'com.esotericsoftware.spine:spine-libgdx:4.0.18.1:sources'
     api 'com.crashinvaders.vfx:gdx-vfx-core:0.5.0:sources'
@@ -53,7 +52,7 @@ dependencies {
 	implementation "com.badlogicgames.gdx-video:gdx-video:1.3.2-SNAPSHOT:sources"
 	implementation "com.badlogicgames.gdx-video:gdx-video-gwt:1.3.2-SNAPSHOT"
 	implementation "com.badlogicgames.gdx-video:gdx-video-gwt:1.3.2-SNAPSHOT:sources"
-	implementation 'com.github.tommyettinger:gdxWalkable:c8244ed4b0:sources'
+	implementation 'com.github.tommyettinger:gdxWalkable:33292ee7da:sources'
 }
 
 import org.akhikhl.gretty.AppBeforeIntegrationTestTask

--- a/html/src/main/java/com/ray3k/template/GdxDefinition.gwt.xml
+++ b/html/src/main/java/com/ray3k/template/GdxDefinition.gwt.xml
@@ -18,6 +18,7 @@
     <inherits name="com.badlogic.gdx.controllers.controllers-gwt"/>
     <inherits name="com.dongbat.jbump" />
     <inherits name="com.badlogic.gdx.video.gdx_video_gwt" />
+    <inherits name="gdxwalkable" />
 	<entry-point class="com.ray3k.template.gwt.GwtLauncher" />
 	<set-configuration-property name="gdx.assetpath" value="../assets" />
 	<set-configuration-property name="xsiframe.failIfScriptTag" value="FALSE"/>


### PR DESCRIPTION
The .gwt.xml file needed an inherits for gdxWalkable. That library also needed to be updated with brand-new changes to account for the flimsy reflection in GWT. ShapeDrawer uses 2.4.0 all over, instead of a mix of versions. RegExodus and Gretty are updated to the current versions. The assets .txt files all use Unix (LF) line endings now; they were mixed before, which breaks the asset manager. That last part is enforced by .gitattributes .

This also updates to Gradle 7.2, which is totally optional. I prefer using the current Gradle and it has basically no breaking changes since 7.0.